### PR TITLE
Disable EMC Nameplate changes for singleplayer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,32 @@
+# Gradle files
 .gradle/
 build/
 out/
 classes/
 *.launch
+gradle/wrapper
+gradlew
+gradlew.bat
+
+# IntelliJ IDEA files
 .idea/
 *.iml
 *.ipr
 *.iws
 .settings/
+
+# VS Code files
 .vscode/
+
+# Eclipse files
 bin/
 .classpath
 .project
+
+# MacOS files
 *.DS_Store
+
+# Java files
 run/
 generated/
 .architectury-transformer/

--- a/common/src/main/java/coffee/waffle/emcutils/mixin/PlayerEntityMixin.java
+++ b/common/src/main/java/coffee/waffle/emcutils/mixin/PlayerEntityMixin.java
@@ -2,6 +2,7 @@ package coffee.waffle.emcutils.mixin;
 
 import coffee.waffle.emcutils.Caches;
 import coffee.waffle.emcutils.Util;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,6 +16,8 @@ import java.util.concurrent.ExecutionException;
 abstract class PlayerEntityMixin {
 	@Inject(method = "getDisplayName", at = @At("HEAD"), cancellable = true)
 	private void emcutils$getDisplayName(CallbackInfoReturnable<Text> cir) {
+		if (MinecraftClient.getInstance().isInSingleplayer()) return; // Don't run anything for singleplayer
+
 		if (Util.isOnEMC) {
 			PlayerEntity e = ((PlayerEntity) (Object) this);
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@
 org.gradle.jvmargs=-Xmx4G
 org.gradle.parallel=true
 
-mod_version=9.0.0
+mod_version=9.0.1


### PR DESCRIPTION
This PR disables the tablist-oriented nameplate changes when in a singleplayer context.

Reason: When in a singleplayer context, the tablist does not exist, so the feature fails to load. 